### PR TITLE
Generate coverage report and send it to Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
     - npm install
 script:
     - npm run lint
-    - npm test
+    - npm run cover
+after_script:
+    - npm run coveralls
 notifications:
     email: false

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "mocha",
     "lint": "eslint .",
-    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\""
+    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",
+    "coveralls": "cat coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",
@@ -27,6 +28,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "coveralls": "^2.11.12",
     "eslint": "^3.4.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\""
   },
   "repository": {
     "type": "git",
@@ -27,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "eslint": "^3.4.0",
+    "istanbul": "^0.4.5",
     "mocha": "^3.0.2",
     "react": "*"
   },


### PR DESCRIPTION
Update Travis to generate test coverage with Istanbul and send report to Coveralls.

Add dependencies:
- [istanbul](https://www.npmjs.com/package/istanbul)
- [coveralls](https://www.npmjs.com/package/coveralls)
