### PR TITLE
Export `REON.parseObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com)
+and this project adheres to [Semantic Versioning](http://semver.org).
+
+## Unreleased
+### Added
+- `REON.parseObject`
+  - Expose object-to-react helper
+- Testing
+- `istanbul` and `coveralls` for coverage reporting
+- Documentation
+  - Add badges and improve links in README
+  - Fix reviver example in README (#3)
+
+## [0.0.1](https://github.com/remarkablemark/REON/tree/v0.0.1) - 2016-09-02
+### Added
+- `REON.stringify`
+  - Converts React element object to string
+- `REON.parse`
+  - Parses string to React element object

--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@
  */
 module.exports = {
     stringify: require('./lib/stringify'),
-    parse: require('./lib/parse')
+    parse: require('./lib/parse'),
+    parseObject: require('./lib/object-to-react')
 };

--- a/test/index.js
+++ b/test/index.js
@@ -11,12 +11,10 @@ var REON = require('../index');
  * REON methods.
  */
 describe('REON', function() {
-
     /**
      * Stringify.
      */
     describe('#stringify', function() {
-
         it('throws an error if argument is invalid', function() {
             var values = [undefined, null, {}, [],'foo', 42, { type: 'div' }];
             values.forEach(function(value) {
@@ -65,14 +63,12 @@ describe('REON', function() {
                 JSON.stringify({ type: 'body' })
             );
         });
-
     });
 
     /**
      * Parse.
      */
     describe('#parse', function() {
-
         it('throws an error if argument is invalid', function() {
             var values = [
                 undefined, null, {}, [], 42, { type: null },
@@ -173,7 +169,14 @@ describe('REON', function() {
                 React.cloneElement(reactElement, { href: 'http://baz.qux' })
             );
         });
-
     });
 
+    /**
+     * Parse object.
+     */
+    describe('#parseObject', function() {
+        it('returns the `objectToReactElement` function', function() {
+            assert.equal(REON.parseObject, require('../lib/object-to-react'));
+        });
+    });
 });


### PR DESCRIPTION
Resolves #5

- Expose `objectToReactElement` as `REON.parseObject`
- Create `CHANGELOG.md`, backfill `0.0.1` release, and update unreleased changes